### PR TITLE
feat: Add extra info string label support

### DIFF
--- a/src/client/codeblock.ts
+++ b/src/client/codeblock.ts
@@ -32,8 +32,16 @@ function addHighlightTool(): void {
     highlightCopy || highlightLang || isHighlightShrink !== undefined;
   const highlightedFigures =
     document.querySelectorAll<HTMLElement>("figure.shiki");
+  const hasMeta = Array.from(highlightedFigures).some(
+    (item) => item.dataset.meta,
+  );
 
-  if (!((isShowTool || highlightHeightLimit) && highlightedFigures.length)) {
+  if (
+    !(
+      (isShowTool || hasMeta || highlightHeightLimit) &&
+      highlightedFigures.length
+    )
+  ) {
     return;
   }
 
@@ -162,12 +170,30 @@ function addHighlightTool(): void {
 
   function createElements(languageMarkup: string, item: HTMLElement): void {
     const fragment = document.createDocumentFragment();
+    const meta = item.dataset.meta;
 
-    if (isShowTool) {
+    if (isShowTool || meta) {
       const highlightTools = document.createElement("div");
       highlightTools.className = `shiki-tools ${highlightShrinkClass}`;
       highlightTools.innerHTML =
         highlightShrinkElement + languageMarkup + highlightCopyElement;
+
+      if (meta) {
+        const metaElement = document.createElement("div");
+        metaElement.className = "code-meta";
+        metaElement.textContent = meta;
+        const languageElement = highlightTools.querySelector(".code-lang");
+        const copyNotice = highlightTools.querySelector(".copy-notice");
+
+        if (languageElement) {
+          languageElement.insertAdjacentElement("afterend", metaElement);
+        } else if (copyNotice) {
+          highlightTools.insertBefore(metaElement, copyNotice);
+        } else {
+          highlightTools.appendChild(metaElement);
+        }
+      }
+
       highlightTools.addEventListener("click", highlightToolsHandler);
       fragment.appendChild(highlightTools);
     }

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -6,7 +6,7 @@ const CODE_BLOCK_PATTERN =
 export interface HtmlHighlighter {
   codeToHtml(
     code: string,
-    options: { lang?: string },
+    options: { lang?: string; meta?: string },
   ): Promise<string> | string;
 }
 
@@ -34,9 +34,17 @@ function stripHighlighterPreAttributes(html: string): string {
   });
 }
 
-function resolveLanguage(args: string): string | undefined {
-  const [language] = args.trim().split(/\s+/, 1);
-  return language || undefined;
+interface CodeBlockArgs {
+  language: string | undefined;
+  meta: string | undefined;
+}
+
+function resolveCodeBlockArgs(args: string): CodeBlockArgs {
+  const trimmed = args.trim();
+  const parts = trimmed.split(/\s+/);
+  const language = parts[0] || undefined;
+  const meta = parts.length > 1 ? parts.slice(1).join(" ") : undefined;
+  return { language, meta };
 }
 
 function shouldSkipHighlight(
@@ -100,7 +108,7 @@ export async function renderMarkdownCodeBlocks(
       ).trimEnd(),
     );
     const lineCount = code.length === 0 ? 1 : code.split("\n").length;
-    const language = resolveLanguage(args);
+    const { language, meta } = resolveCodeBlockArgs(args);
     let html = "";
 
     if (shouldSkipHighlight(language, options.skipLanguages)) {
@@ -114,14 +122,18 @@ export async function renderMarkdownCodeBlocks(
 
     try {
       html = stripHighlighterPreAttributes(
-        await highlighter.codeToHtml(code, { lang: language }),
+        await highlighter.codeToHtml(code, { lang: language, meta }),
       );
     } catch (error) {
       console.warn(error);
       html = `<pre><code>${escapeHtml(code)}</code></pre>`;
     }
 
-    let codeBlockHtml = `<figure class="shiki${language ? ` ${language}` : ""}">`;
+    const metaAttr = meta ? ` data-meta="${escapeHtml(meta)}"` : "";
+    let codeBlockHtml = `<figure class="shiki${language ? ` ${language}` : ""}"${metaAttr}>`;
+    if (meta) {
+      codeBlockHtml += `<div class="code-meta">${escapeHtml(meta)}</div>`;
+    }
     codeBlockHtml += "<div class='codeblock'>";
 
     if (options.lineNumber) {

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -131,9 +131,6 @@ export async function renderMarkdownCodeBlocks(
 
     const metaAttr = meta ? ` data-meta="${escapeHtml(meta)}"` : "";
     let codeBlockHtml = `<figure class="shiki${language ? ` ${language}` : ""}"${metaAttr}>`;
-    if (meta) {
-      codeBlockHtml += `<div class="code-meta">${escapeHtml(meta)}</div>`;
-    }
     codeBlockHtml += "<div class='codeblock'>";
 
     if (options.lineNumber) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ async function highlightCode(
   theme: string,
   colorizedBrackets?: ResolvedShikiPluginConfig["colorizedBrackets"],
   lang?: string,
+  meta?: string,
 ): Promise<string> {
   const transformers = colorizedBrackets
     ? [
@@ -34,14 +35,20 @@ async function highlightCode(
         ),
       ]
     : undefined;
-  const options = {
+  const options: Record<string, unknown> = {
     lang: lang ?? "text",
     theme,
     transformers,
-  } as unknown as ShikiCodeToHtmlOptions;
+  };
+
+  if (meta) {
+    options.meta = { __raw: meta };
+  }
+
+  const optionsTyped = options as unknown as ShikiCodeToHtmlOptions;
 
   try {
-    return await codeToHtml(code, options);
+    return await codeToHtml(code, optionsTyped);
   } catch {
     return codeToHtml(code, {
       lang: "text",
@@ -99,12 +106,13 @@ export async function initializePlugin(hexo: HexoGlobal): Promise<void> {
       post.content,
       { lineNumber: config.lineNumber, skipLanguages: config.skipLanguages },
       {
-        codeToHtml(source, { lang }) {
+        codeToHtml(source, { lang, meta }) {
           return highlightCode(
             source,
             highlightTheme,
             config.colorizedBrackets,
             lang,
+            meta,
           );
         },
       },

--- a/src/styles/codeblock.css
+++ b/src/styles/codeblock.css
@@ -11,6 +11,15 @@ figure.shiki div.codeblock::-webkit-scrollbar {
 figure.shiki .shiki-tools.closed ~ * {
   display: none;
 }
+figure.shiki .code-meta {
+  padding: 2px 14px;
+  font-size: 0.85em;
+  font-family: Consolas, "Fira Code", "Fira Mono", Menlo, "DejaVu Sans Mono", monospace, sans-serif;
+  background: var(--hltools-bg);
+  color: var(--hltools-color);
+  border-bottom: 1px solid rgba(128, 128, 128, 0.15);
+  user-select: none;
+}
 figure.shiki div.codeblock {
   margin: 0;
 }

--- a/src/styles/codeblock.css
+++ b/src/styles/codeblock.css
@@ -11,13 +11,24 @@ figure.shiki div.codeblock::-webkit-scrollbar {
 figure.shiki .shiki-tools.closed ~ * {
   display: none;
 }
-figure.shiki .code-meta {
-  padding: 2px 14px;
-  font-size: 0.85em;
-  font-family: Consolas, "Fira Code", "Fira Mono", Menlo, "DejaVu Sans Mono", monospace, sans-serif;
-  background: var(--hltools-bg);
+figure.shiki .shiki-tools .code-lang,
+figure.shiki .shiki-tools .code-meta {
+  font-weight: 700;
+  line-height: 1;
   color: var(--hltools-color);
-  border-bottom: 1px solid rgba(128, 128, 128, 0.15);
+}
+figure.shiki .shiki-tools .code-meta {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0 5em 0 0.75em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 1rem;
+  font-family:
+    Consolas, "Fira Code", "Fira Mono", Menlo, "DejaVu Sans Mono", monospace,
+    sans-serif;
+  opacity: 0.78;
   user-select: none;
 }
 figure.shiki div.codeblock {
@@ -97,10 +108,9 @@ figure.shiki .shiki-tools .expand.closed::before {
   transform: rotate(90deg);
 }
 figure.shiki .shiki-tools .code-lang {
-  left: 75px;
-  position: absolute;
+  flex: 0 0 auto;
+  margin-left: 75px;
   text-transform: uppercase;
-  font-weight: 700;
   font-size: 1.15em;
   -webkit-user-select: none;
   -moz-user-select: none;

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -76,6 +76,41 @@ describe("renderMarkdownCodeBlocks", () => {
     expect(highlighter).not.toHaveBeenCalled();
   });
 
+  it("renders fenced blocks with meta / file path info", async () => {
+    const highlighter = vi.fn().mockResolvedValue("<pre><code>highlighted</code></pre>");
+
+    const html = await renderMarkdownCodeBlocks(
+      "```js /etc/scripts/ps.js\nconst value = 1;\n```\n",
+      { lineNumber: false },
+      { codeToHtml: highlighter },
+    );
+
+    expect(html).toContain('<div class="code-meta">/etc/scripts/ps.js</div>');
+    expect(html).toContain('data-meta="/etc/scripts/ps.js"');
+    expect(html).toContain('<figure class="shiki js"');
+    expect(highlighter).toHaveBeenCalledWith("const value = 1;", {
+      lang: "js",
+      meta: "/etc/scripts/ps.js",
+    });
+  });
+
+  it("does not render code-meta when no path is given", async () => {
+    const highlighter = vi.fn().mockResolvedValue("<pre><code>highlighted</code></pre>");
+
+    const html = await renderMarkdownCodeBlocks(
+      "```js\nconst value = 1;\n```\n",
+      { lineNumber: false },
+      { codeToHtml: highlighter },
+    );
+
+    expect(html).not.toContain("code-meta");
+    expect(html).not.toContain("data-meta");
+    expect(highlighter).toHaveBeenCalledWith("const value = 1;", {
+      lang: "js",
+      meta: undefined,
+    });
+  });
+
   it("leaves other skipped languages for downstream renderers", async () => {
     const markdown = "```dot\ndigraph G { A -> B }\n```\n";
     const highlighter = vi

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -77,7 +77,9 @@ describe("renderMarkdownCodeBlocks", () => {
   });
 
   it("renders fenced blocks with meta / file path info", async () => {
-    const highlighter = vi.fn().mockResolvedValue("<pre><code>highlighted</code></pre>");
+    const highlighter = vi
+      .fn()
+      .mockResolvedValue("<pre><code>highlighted</code></pre>");
 
     const html = await renderMarkdownCodeBlocks(
       "```js /etc/scripts/ps.js\nconst value = 1;\n```\n",
@@ -85,8 +87,8 @@ describe("renderMarkdownCodeBlocks", () => {
       { codeToHtml: highlighter },
     );
 
-    expect(html).toContain('<div class="code-meta">/etc/scripts/ps.js</div>');
     expect(html).toContain('data-meta="/etc/scripts/ps.js"');
+    expect(html).not.toContain('<div class="code-meta">');
     expect(html).toContain('<figure class="shiki js"');
     expect(highlighter).toHaveBeenCalledWith("const value = 1;", {
       lang: "js",
@@ -95,7 +97,9 @@ describe("renderMarkdownCodeBlocks", () => {
   });
 
   it("does not render code-meta when no path is given", async () => {
-    const highlighter = vi.fn().mockResolvedValue("<pre><code>highlighted</code></pre>");
+    const highlighter = vi
+      .fn()
+      .mockResolvedValue("<pre><code>highlighted</code></pre>");
 
     const html = await renderMarkdownCodeBlocks(
       "```js\nconst value = 1;\n```\n",

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -36,4 +36,13 @@ describe("codeblock styles", () => {
       /figure\.shiki \.shiki-tools \.expand ~ \.copy-notice \{[\s\S]*right: 3\.8em;[\s\S]*display: flex;[\s\S]*align-items: center;[\s\S]*line-height: 1;/,
     );
   });
+
+  it("keeps code metadata on the toolbar next to the language", () => {
+    expect(css).toMatch(
+      /figure\.shiki \.shiki-tools \.code-meta \{[\s\S]*flex: 1 1 auto;[\s\S]*white-space: nowrap;[\s\S]*font-size: 1rem;[\s\S]*Consolas/,
+    );
+    expect(css).toMatch(
+      /figure\.shiki \.shiki-tools \.code-lang \{[\s\S]*margin-left: 75px;/,
+    );
+  });
 });


### PR DESCRIPTION
添加了对于信息字符串的额外支持，类似highlight.js。

## 功能

当源文件代码块头类似 \`\`\`js script.js 时，`script.js`这段文字将显示在代码块标题栏的下方、实际代码的上方。